### PR TITLE
[FIX] Retry PokeAPI fetches with backoff and check response status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ users.html
 
 #js generated with tsc
 *.js
+
+#html generated with the generator
+*.html

--- a/fetch-json.ts
+++ b/fetch-json.ts
@@ -1,0 +1,20 @@
+const RETRY_DELAYS_MS = [1000, 5000, 15000];
+
+export async function fetchJson(url: string): Promise<any> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status} ${response.statusText}`);
+      }
+      return await response.json();
+    } catch (error) {
+      if (attempt >= RETRY_DELAYS_MS.length) {
+        throw new Error(`Failed to fetch ${url} after ${RETRY_DELAYS_MS.length + 1} attempts: ${error}`);
+      }
+      const delay = RETRY_DELAYS_MS[attempt];
+      console.warn(`Fetch failed for ${url} (${error}), retrying in ${delay / 1000}s...`);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}

--- a/pokemon-detail.ts
+++ b/pokemon-detail.ts
@@ -1,3 +1,5 @@
+import { fetchJson } from "./fetch-json";
+
 interface DamageRelation {
   double_damage_from: { name: string }[];
   half_damage_from: { name: string }[];
@@ -65,10 +67,8 @@ export class PokemonDetails {
 
   export const loadPokemonDetails = async (id: number): Promise<PokemonDetails | undefined> => {
     try {
-      const response = await fetch(`https://pokeapi.co/api/v2/pokemon/${id}`);
-      const data = await response.json();
-      const speciesResponse = await fetch(`https://pokeapi.co/api/v2/pokemon-species/${id}`);
-      const speciesData = await speciesResponse.json();
+      const data = await fetchJson(`https://pokeapi.co/api/v2/pokemon/${id}`);
+      const speciesData = await fetchJson(`https://pokeapi.co/api/v2/pokemon-species/${id}`);
       const imageUrl = data.sprites.front_default;
       const officialArtworkUrl = data.sprites.other["official-artwork"].front_default;
       const officialArtworkShinyUrl = data.sprites.other["official-artwork"].front_shiny || officialArtworkUrl;
@@ -155,8 +155,7 @@ export class PokemonDetails {
   async function getAbilitiesDescriptions(abilities: { ability: { url: string } }[]): Promise<string[]> {
     const descriptions = await Promise.all(
       abilities.map(async ({ ability: { url } }) => {
-        const response = await fetch(url);
-        const data = await response.json();
+        const data = await fetchJson(url);
         const englishDescription = data.effect_entries.find((entry: { language: { name: string } }) => entry.language.name === 'en');
         return englishDescription ? englishDescription.effect : 'No description available';
       })
@@ -165,8 +164,7 @@ export class PokemonDetails {
   }
 
   async function getPokemonDescriptions(pokemonId: number): Promise<DexDescription[]> {
-    const response = await fetch(`https://pokeapi.co/api/v2/pokemon-species/${pokemonId}`);
-    const data = await response.json();
+    const data = await fetchJson(`https://pokeapi.co/api/v2/pokemon-species/${pokemonId}`);
     const englishFlavorTextEntries = data.flavor_text_entries.filter((entry: { language: { name: string } }) => entry.language.name === 'en');
     if (englishFlavorTextEntries.length > 0) {
       const pokedexDescriptions: DexDescription[] = englishFlavorTextEntries.map((entry: { flavor_text: string; version: { name: string } }) => {
@@ -187,14 +185,12 @@ export class PokemonDetails {
     superResistantTo: string[];
     immuneTo: string[];
   }> {
-    const response = await fetch(`https://pokeapi.co/api/v2/pokemon/${pokemonId}`);
-    const data = await response.json();
+    const data = await fetchJson(`https://pokeapi.co/api/v2/pokemon/${pokemonId}`);
     const types = data.types.map((type: { type: { url: string } }) => type.type);
 
     const damageRelations: DamageRelation[] = await Promise.all(types.map(async (type: { url: string }) => {
-      const response = await fetch(type.url);
-      const data = await response.json();
-      return data.damage_relations;
+      const typeData = await fetchJson(type.url);
+      return typeData.damage_relations;
     }));
 
     const pokemonTypes = [
@@ -255,16 +251,14 @@ export class PokemonDetails {
     if (!evolutionChainUrl) return [];
     
     try {
-      const response = await fetch(evolutionChainUrl);
-      const data = await response.json();
+      const data = await fetchJson(evolutionChainUrl);
       
       const processChain = async (chain: any): Promise<EvolutionStep> => {
         const speciesName = chain.species.name;
         const speciesUrl = chain.species.url;
         const speciesId = parseInt(speciesUrl.split('/').filter(Boolean).pop());
         
-        const pokemonResponse = await fetch(`https://pokeapi.co/api/v2/pokemon/${speciesId}`);
-        const pokemonData = await pokemonResponse.json();
+        const pokemonData = await fetchJson(`https://pokeapi.co/api/v2/pokemon/${speciesId}`);
         const imageUrl = pokemonData.sprites.other["official-artwork"].front_default;
         
         let trigger = '';

--- a/pokemon.ts
+++ b/pokemon.ts
@@ -1,3 +1,5 @@
+import { fetchJson } from "./fetch-json";
+
 export class Pokemon {
     constructor(
       public id: number,
@@ -21,12 +23,9 @@ export class Pokemon {
     const pokemons: Array<Pokemon> = [];
 
     for (let i = 1; i <= n; i++) {
-        const response = await fetch(`https://pokeapi.co/api/v2/pokemon/${i}`);
-        const speciesResponse = await fetch(`https://pokeapi.co/api/v2/pokemon-species/${i}`);
-
-        if (response.ok && speciesResponse.ok) {
-            const data = await response.json();
-            const speciesData = await speciesResponse.json();
+        try {
+            const data = await fetchJson(`https://pokeapi.co/api/v2/pokemon/${i}`);
+            const speciesData = await fetchJson(`https://pokeapi.co/api/v2/pokemon-species/${i}`);
 
             const imageUrl = data.sprites.front_default;
             const officialArtworkUrl = data.sprites.other["official-artwork"].front_default;
@@ -40,8 +39,8 @@ export class Pokemon {
             const generation = speciesData.generation?.name || 'unknown';
 
             pokemons.push(new Pokemon(i, name, codename, imageUrl, types, is_baby, is_legendary, is_mythical, officialArtworkUrl, generation));
-        } else {
-            console.error(`Error fetching data for Pokémon ID ${i}: ${response.statusText}`);
+        } catch (error) {
+            console.error(`Error fetching data for Pokémon ID ${i}:`, error);
         }
     }
     return pokemons;


### PR DESCRIPTION
The generator called response.json() without checking response.ok, so transient PokeAPI errors (rate limits, 5xx) returned as HTML pages crashed JSON parsing and silently produced pages with missing data (e.g. empty evolution chains). Route all generator-side fetches through a fetchJson helper that validates the status and retries up to 3 times (1s, 5s, 15s) before giving up.